### PR TITLE
solved # 128 Get rid of Jupyter Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*/.ipynb_checkpoints/*
 
 # IPython
 profile_default/
@@ -136,3 +137,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
please fill out the following.
Happy Contributing!
-->

### Have you read the [Contributing Guidelines on Pull Requests](https://github.com/HakinCodes/Malaria-Detection/blob/master/CONTRIBUTING.md)?

Yes

### Description

Get rid of .ipynb_checkpoints by adding the hidden directory to the gitignore file.

### Checklist

- [x] I've read the contribution guidelines.
- [x] This PR mets all the requirements like Clean Code, proper README and Documentation

### Related Issues or Pull Requests

Fixes: #128 



